### PR TITLE
Fix bug in list-max 

### DIFF
--- a/software.html
+++ b/software.html
@@ -1023,12 +1023,13 @@ check:
 end
 
 fun list-max(lon :: List&lt;Number&gt;) -&gt; Number:
-  fold(lam(acc, n): if n &gt; acc: n else: acc end end, 0, lon)
+  fold(lam(acc, n): if ((acc == "start") or (n &gt; acc)): n else: acc end end, "start", lon)
 end
 check:
   list-max([list: -1, 1, 2]) is 2
   list-max([list: 0, -100, 1]) is 1
   list-max([list: 1/2, 3/4]) is 3/4
+  list-max([list: -1, -2, -3]) is -1
 end
 </pre>
 </details>


### PR DESCRIPTION
list-max has a bug which gives incorrect answer for list containing all negative elements. This is because the base is chosen as 0, which won't change if all elements are less than 0 in the list. The answer for list-max on a list with all negative elements will therefore be 0.